### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: pre-commit
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/devalv/mockapi/security/code-scanning/2](https://github.com/devalv/mockapi/security/code-scanning/2)

To fix the problem, explicitly specify minimal permissions for the workflow or job. The best method is to add a `permissions` block at the workflow level (top-level, near the top of `.github/workflows/pre-commit.yml`) to keep the workflow configuration clear and secure by default. Since the workflow as shown only checks code out and runs pre-commit checks with no indication of needing repository modifications, `contents: read` is the minimal and most appropriate permission. This should be added after the workflow name and before the `on:` block—for consistency and clarity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
